### PR TITLE
Load shared commitlint preset in Actions

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,0 @@
-module.exports = { extends: ['@fingerprintjs/commit-lint-dx-team'] };

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,1 @@
+export default { extends: ['@fingerprintjs/commit-lint-dx-team'] };


### PR DESCRIPTION
Rename `commitlint.config.js` to `commitlint.config.mjs` so [wagoid/commitlint-github-action](https://github.com/wagoid/commitlint-github-action/blob/v6.1.0/action.yml) loads `@fingerprintjs/commit-lint-dx-team` instead of falling back to `@commitlint/config-conventional`.