### PR TITLE
INTER-2051: Add SDK version support and EOL table to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,13 @@ Class | Method | HTTP request | Description
 - [SealedResults](docs/SealedResults.md)
 - [DecryptionKey](docs/DecryptionKey.md)
 
+## Version support
+
+| SDK major version | Server API version | Status | End of support | Notes |
+|---|---|---|---|---|
+| v9.x (current) | [v4](https://docs.fingerprint.com/reference/server-api) | Supported | - | - |
+| v1.x-v8.x | [v3](https://docs.fingerprint.com/reference/v3/server-api) | Deprecated (security fixes only). See the [migration guide](https://docs.fingerprint.com/reference/python-server-sdk#migration-guide-for-python-sdk-v9). | To be decided | Maintained in the [old repository](https://github.com/fingerprintjs/fingerprint-pro-server-api-python-sdk) |
+
 ## Support
 
 To report problems, ask questions or provide feedback, please use [Issues](https://github.com/fingerprintjs/python-sdk/issues).

--- a/README.md
+++ b/README.md
@@ -381,10 +381,10 @@ Class | Method | HTTP request | Description
 
 ## Version support
 
-| SDK major version | Server API version | Status | End of support | Notes |
-|---|---|---|---|---|
-| v9.x (current) | [v4](https://docs.fingerprint.com/reference/server-api) | Supported | - | - |
-| v1.x-v8.x | [v3](https://docs.fingerprint.com/reference/v3/server-api) | Deprecated (security fixes only). See the [migration guide](https://docs.fingerprint.com/reference/python-server-sdk#migration-guide-for-python-sdk-v9). | To be decided | Maintained in the [old repository](https://github.com/fingerprintjs/fingerprint-pro-server-api-python-sdk) |
+| SDK major version | Server API version | Status | End of support |
+|---|---|---|---|
+| v9.x (current) | [v4](https://docs.fingerprint.com/reference/server-api) | Supported | - |
+| v1.x-v8.x | [v3](https://docs.fingerprint.com/reference/v3/server-api) | Deprecated (security fixes only). See the [migration guide](https://docs.fingerprint.com/reference/python-server-sdk#migration-guide-for-python-sdk-v9). | To be decided |
 
 ## Support
 

--- a/template/README.mustache
+++ b/template/README.mustache
@@ -70,10 +70,10 @@ Please follow the [installation procedure](#installation--usage) and then run th
 
 ## Version support
 
-| SDK major version | Server API version | Status | End of support | Notes |
-|---|---|---|---|---|
-| v9.x (current) | [v4](https://docs.fingerprint.com/reference/server-api) | Supported | - | - |
-| v1.x-v8.x | [v3](https://docs.fingerprint.com/reference/v3/server-api) | Deprecated (security fixes only). See the [migration guide](https://docs.fingerprint.com/reference/python-server-sdk#migration-guide-for-python-sdk-v9). | To be decided | Maintained in the [old repository](https://github.com/fingerprintjs/fingerprint-pro-server-api-python-sdk) |
+| SDK major version | Server API version | Status | End of support |
+|---|---|---|---|
+| v9.x (current) | [v4](https://docs.fingerprint.com/reference/server-api) | Supported | - |
+| v1.x-v8.x | [v3](https://docs.fingerprint.com/reference/v3/server-api) | Deprecated (security fixes only). See the [migration guide](https://docs.fingerprint.com/reference/python-server-sdk#migration-guide-for-python-sdk-v9). | To be decided |
 
 ## Support
 

--- a/template/README.mustache
+++ b/template/README.mustache
@@ -68,6 +68,13 @@ Please follow the [installation procedure](#installation--usage) and then run th
 
 {{> common_README }}
 
+## Version support
+
+| SDK major version | Server API version | Status | End of support | Notes |
+|---|---|---|---|---|
+| v9.x (current) | [v4](https://docs.fingerprint.com/reference/server-api) | Supported | - | - |
+| v1.x-v8.x | [v3](https://docs.fingerprint.com/reference/v3/server-api) | Deprecated (security fixes only). See the [migration guide](https://docs.fingerprint.com/reference/python-server-sdk#migration-guide-for-python-sdk-v9). | To be decided | Maintained in the [old repository](https://github.com/fingerprintjs/fingerprint-pro-server-api-python-sdk) |
+
 ## Support
 
 To report problems, ask questions or provide feedback, please use [Issues](https://{{{gitHost}}}/{{{gitUserId}}}/{{{gitRepoId}}}/issues).


### PR DESCRIPTION
This PR addresses concerns raised in [INTER-2051](https://fingerprintjs.atlassian.net/browse/INTER-2051). This is one PR as a part of a thread of PRs that will need to be made for each SDK.

Adds a "Version support" section to the README with a single table showing which SDK major versions map to which Server API version, their current status, and end-of-support info.

[INTER-2051]: https://fingerprintjs.atlassian.net/browse/INTER-2051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ