### PR TITLE
ci: deploy coverage report via GitHub Pages Actions artifact

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -5,11 +5,16 @@ on:
       - main
       - coverage # remove before merge to main
 
-permissions:
-  contents: write
+concurrency:
+  group: coverage-report-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  coverage-report:
+  build:
+    name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
@@ -33,8 +38,22 @@ jobs:
           output: htmlcov/badges.svg
           jsonPath: total.statements.pct
 
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
+      - name: Upload GitHub Pages artifact 📦
+        uses: actions/upload-pages-artifact@v5
         with:
-          branch: gh-pages
-          folder: htmlcov
+          path: htmlcov
+
+  deploy-pages:
+    name: Deploy to GitHub Pages 🚀
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Now that signed commits are required, `JamesIves/github-pages-deploy-action` can no longer push to the `gh-pages` branch. Followed the same solution from this PR: https://github.com/fingerprintjs/fingerprint-pro-server-api-openapi/pull/464

Changes:
- Replace the `gh-pages` branch push with `actions/upload-pages-artifact` + `actions/deploy-pages`
- Split the single `coverage-report` job into `build` and `deploy-pages`
- Drop the workflow-level `contents: write` permission, since nothing pushes to a branch anymore

## :warning: Before merging

Switch the Pages source to GitHub Actions. More details [here](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow). Requires repo admin, so someone with that access will need to run this (from the UI, or via the `gh` API command below):

```
gh api -X PUT repos/fingerprintjs/python-sdk/pages -f build_type=workflow
```

Slack ref relevant to this process: https://fingerprintjs.slack.com/archives/C050TKU9X5L/p1788168387519619